### PR TITLE
require 'yaml' in subtag.rb

### DIFF
--- a/lib/iso/subtag.rb
+++ b/lib/iso/subtag.rb
@@ -1,3 +1,5 @@
+require 'yaml'
+
 module ISO
   class Subtag
     attr_reader :code


### PR DESCRIPTION
This is a really small one: YAML is used, but not required. ;-)